### PR TITLE
Add option to auto-reset to current player

### DIFF
--- a/components/frame.lua
+++ b/components/frame.lua
@@ -84,6 +84,13 @@ function Frame:OnHide()
 
 	if self:IsFrameShown() then -- for when a frame is hidden not via bagnon
 		self:HideFrame()
+		-- self:SetPlayer(nil)
+		-- ^ Currently the only case this seems to catch is closing the frame
+		-- using the Esc key, but this shouldn't behave any differently than
+		-- closing the frame using its close button or assigned keybinding.
+	end
+
+	if Addon.sets.autoResetPlayer then
 		self:SetPlayer(nil)
 	end
 end
@@ -184,7 +191,7 @@ function Frame:FadeInFrame(frame, alpha)
 	if Addon.sets.fading then
 		UIFrameFadeIn(frame, 0.2, 0, alpha or 1)
 	end
-	
+
 	frame:Show()
 end
 
@@ -429,7 +436,7 @@ function Frame:PlaceBagFrame()
 	end
 
 	return 0, 0
-end 
+end
 
 
 -- title frame


### PR DESCRIPTION
This is one of a four-part pull request (Bagnon, Bagnon_Config, Bagnon_VoidStorage, and Wildpants) that does the following:

1. Adds an option to automatically reset to the current player when closing and reopening any window.

2. Always resets the bank and void storage windows to the current player when clicking on a bank or void storage NPC. (fix for #404)

See also:

- https://github.com/tullamods/Bagnon_Config/pull/11
- https://github.com/Jaliborc/Bagnon_VoidStorage/pull/1
- https://github.com/tullamods/Wildpants/pull/3